### PR TITLE
SSL対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,25 @@ FROM ynoami/java
 
 MAINTAINER ynoami<nyata100@gmail.com>
 
+ENV BITB_VERSION 4.1.0
+
 RUN apt-get install curl git -y
-RUN curl -L -O https://www.atlassian.com/software/stash/downloads/binary/atlassian-bitbucket-4.1.0.tar.gz \
+RUN curl -L -O https://www.atlassian.com/software/stash/downloads/binary/atlassian-bitbucket-${BITB_VERSION}.tar.gz \
     && mkdir -p /opt/atlassian \
-    && tar -zxvf atlassian-bitbucket-4.1.0.tar.gz -C /opt/atlassian \
-    && rm atlassian-bitbucket-4.1.0.tar.gz
+    && tar -zxvf atlassian-bitbucket-${BITB_VERSION}.tar.gz -C /opt/atlassian \
+    && rm atlassian-bitbucket-${BITB_VERSION}.tar.gz
 
 RUN useradd --create-home --comment "Account for runnning stash" --shell /bin/bash stash
 
 RUN mkdir -p /var/atlassian/application-data/bitbucket
 RUN chown -R stash /opt/atlassian/
 RUN chgrp -R stash /opt/atlassian/
-RUN cp /opt/atlassian/atlassian-bitbucket-4.1.0/conf/server.xml /var/atlassian/application-data/bitbucket
+RUN cp /opt/atlassian/atlassian-bitbucket-${BITB_VERSION}/conf/server.xml /var/atlassian/application-data/bitbucket
 
 #ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV BITBUCKET_HOME /var/atlassian/application-data/bitbucket
 
+COPY entrypoint.sh /sbin/entrypoint.sh
+RUN chmod 755 /sbin/entrypoint.sh
 
-ENTRYPOINT ["/opt/atlassian/atlassian-bitbucket-4.1.0/bin/start-bitbucket.sh", "-fg"]
-
-
+ENTRYPOINT ["/sbin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# 環境変数 $SSL がTRUEのときはserver.xmlを編集し、SSL接続待ち受けコネクタを追加する
+# ただし、各SSLパラメータが定義されていないときはコンテナを停止させる
+# 既にSSL接続待ち受けコネクタが追加されているときはserver.xmlを編集せずそのままにする
+if [ "${SSL}" = "TRUE" ]; then
+ isMod=$(grep "SSLCONNECTOR_INSERT" -c /opt/atlassian/atlassian-bitbucket-${BITB_VERSION}/conf/server.xml)
+
+ if [ "${KEYSTORE_PATH}" = "" ]; then
+  echo "UNDEFINED KEYSTORE_PATH"
+  exit
+ elif [ "${KEYSTORE_PASS}" = "" ]; then
+  echo "UNDEFINED KEYSTORE_PASS"
+  exit
+ elif [ "${KEYALIAS}" = "" ]; then
+  echo "UNDEFINED KEYALIAS"
+  exit
+ elif [ ${isMod} -ne 0 ]; then
+  echo "Already SSL connector is registered"
+ fi
+
+ sed -i 's|</Service>|<Connector port="8443" protocol="org.apache.coyote.http11.Http11Protocol" maxHttpHeaderSize="8192" \
+  SSLEnabled="true" maxThreads="150" minSpareThreads="25" enableLookups="false" disableUploadTimeout="true" acceptCount="100" \
+  scheme="https" secure="true" clientAuth="false" sslProtocol="TLS" useBodyEncodingForURI="true" keyAlias="'${KEYALIAS}'" \
+  keystoreFile="'${KEYSTORE_PATH}'" keystorePass="'${KEYSTORE_PASS}'" keystoreType="JKS"/>\n<!--SSLCONNECTOR_INSERT-->\n </Service>|g' \
+  /opt/atlassian/atlassian-bitbucket-${BITB_VERSION}/conf/server.xml
+  echo "SSL connector is registered"
+else
+ echo "SSL=FALSE"
+fi
+
+/opt/atlassian/atlassian-bitbucket-${BITB_VERSION}/bin/start-bitbucket.sh -fg


### PR DESCRIPTION
dockerのENVで下記のSSLパラメータを指定すると、SSL接続待ち受けコネクタを追加するようにしました。
・SSL ： SSL接続をしたいときはTRUE　したくないときはFALSE、もしくは定義なし
・KEYALIAS ： キーのエイリアス
・KEYSTORE_PATH ： キーストアのパス
・KEYSTORE_PASS ： キーストアのパスワード
